### PR TITLE
Upgrade packages and fix NUnit 4 test breakage

### DIFF
--- a/osu.Framework.Font.Tests/Extensions/RectangleFExtensionsTest.cs
+++ b/osu.Framework.Font.Tests/Extensions/RectangleFExtensionsTest.cs
@@ -20,9 +20,9 @@ public class RectangleFExtensionsTest
         var rectangle = new RectangleF(10, 10, 20, 10);
         var target = rectangle.Scale(scale, origin);
 
-        Assert.AreEqual(target.X, x);
-        Assert.AreEqual(target.Y, y);
-        Assert.AreEqual(target.Width, width);
-        Assert.AreEqual(target.Height, height);
+        Assert.That(x, Is.EqualTo(target.X));
+        Assert.That(y, Is.EqualTo(target.Y));
+        Assert.That(width, Is.EqualTo(target.Width));
+        Assert.That(height, Is.EqualTo(target.Height));
     }
 }

--- a/osu.Framework.Font.Tests/Graphics/Sprites/KaraokeSpriteTextTest.cs
+++ b/osu.Framework.Font.Tests/Graphics/Sprites/KaraokeSpriteTextTest.cs
@@ -18,7 +18,7 @@ public class KaraokeSpriteTextTest
         var expectedInterpolatedTimeTags = TestCaseTagHelper.ParseTimeTags(expectedTimeTags);
         var actualInterpolatedTimeTags = KaraokeSpriteText.GetInTheRangeTimeTags(TestCaseTagHelper.ParseTimeTags(timeTags), "カラオケ");
 
-        Assert.AreEqual(expectedInterpolatedTimeTags, actualInterpolatedTimeTags);
+        Assert.That(actualInterpolatedTimeTags, Is.EqualTo(expectedInterpolatedTimeTags));
     }
 
     [TestCase(new[] { "[0,start]:500", "[0,end]:600" },
@@ -38,7 +38,7 @@ public class KaraokeSpriteTextTest
         var expectedInterpolatedTimeTags = TestCaseTagHelper.ParseTimeTags(expectedTimeTags);
         var actualInterpolatedTimeTags = KaraokeSpriteText.GetNonDuplicatedTimeTags(TestCaseTagHelper.ParseTimeTags(timeTags));
 
-        Assert.AreEqual(expectedInterpolatedTimeTags, actualInterpolatedTimeTags);
+        Assert.That(actualInterpolatedTimeTags, Is.EqualTo(expectedInterpolatedTimeTags));
     }
 
     [TestCase(new[] { "[0,start]:500", "[0,end]:600" },
@@ -68,6 +68,6 @@ public class KaraokeSpriteTextTest
         var expectedInterpolatedTimeTags = TestCaseTagHelper.ParseTimeTags(expectedTimeTags);
         var actualInterpolatedTimeTags = KaraokeSpriteText.GetInterpolatedTimeTags(TestCaseTagHelper.ParseTimeTags(timeTags));
 
-        Assert.AreEqual(expectedInterpolatedTimeTags, actualInterpolatedTimeTags);
+        Assert.That(actualInterpolatedTimeTags, Is.EqualTo(expectedInterpolatedTimeTags));
     }
 }

--- a/osu.Framework.Font.Tests/Graphics/Sprites/LyricSpriteTextTest.cs
+++ b/osu.Framework.Font.Tests/Graphics/Sprites/LyricSpriteTextTest.cs
@@ -18,7 +18,7 @@ public class LyricSpriteTextTest
     {
         var expected = TestCaseTagHelper.ParsePositionTexts(fixedPositionTexts);
         var actual = LyricSpriteText.GetFixedPositionTexts(TestCaseTagHelper.ParsePositionTexts(positionTexts), lyric);
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [TestCase("カラオケ", "[0]:か", "[0]:か")]
@@ -35,6 +35,6 @@ public class LyricSpriteTextTest
     {
         var expected = fixedPositionText != null ? TestCaseTagHelper.ParsePositionText(fixedPositionText) : default(PositionText?);
         var actual = LyricSpriteText.GetFixedPositionText(TestCaseTagHelper.ParsePositionText(positionText), lyric);
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 }

--- a/osu.Framework.Font.Tests/Graphics/TextIndexTest.cs
+++ b/osu.Framework.Font.Tests/Graphics/TextIndexTest.cs
@@ -14,7 +14,7 @@ public class TextIndexTest
     [TestCase("-1,start")]
     public void TestOperatorEqual(string textIndex1)
     {
-        Assert.AreEqual(TestCaseTextIndexHelper.ParseTextIndex(textIndex1), TestCaseTextIndexHelper.ParseTextIndex(textIndex1));
+        Assert.That(TestCaseTextIndexHelper.ParseTextIndex(textIndex1), Is.EqualTo(TestCaseTextIndexHelper.ParseTextIndex(textIndex1)));
     }
 
     [TestCase("-1,start", "1,start")]
@@ -25,7 +25,7 @@ public class TextIndexTest
     [TestCase("-2,end", "-2,start")]
     public void TestOperatorNotEqual(string textIndex1, string textIndex2)
     {
-        Assert.AreNotEqual(TestCaseTextIndexHelper.ParseTextIndex(textIndex1), TestCaseTextIndexHelper.ParseTextIndex(textIndex2));
+        Assert.That(TestCaseTextIndexHelper.ParseTextIndex(textIndex2), Is.Not.EqualTo(TestCaseTextIndexHelper.ParseTextIndex(textIndex1)));
     }
 
     [TestCase("1,start", "0,start", true)]
@@ -34,7 +34,7 @@ public class TextIndexTest
     [TestCase("1,start", "1,end", false)]
     public void TestOperatorGreater(string textIndex1, string textIndex2, bool match)
     {
-        Assert.AreEqual(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) > TestCaseTextIndexHelper.ParseTextIndex(textIndex2), match);
+        Assert.That(match, Is.EqualTo(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) > TestCaseTextIndexHelper.ParseTextIndex(textIndex2)));
     }
 
     [TestCase("1,start", "0,start", true)]
@@ -43,7 +43,7 @@ public class TextIndexTest
     [TestCase("1,start", "1,end", false)]
     public void TestOperatorGreaterOrEqual(string textIndex1, string textIndex2, bool match)
     {
-        Assert.AreEqual(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) >= TestCaseTextIndexHelper.ParseTextIndex(textIndex2), match);
+        Assert.That(match, Is.EqualTo(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) >= TestCaseTextIndexHelper.ParseTextIndex(textIndex2)));
     }
 
     [TestCase("-1,start", "0,start", true)]
@@ -52,7 +52,7 @@ public class TextIndexTest
     [TestCase("-1,start", "-2,end", false)]
     public void TestOperatorLess(string textIndex1, string textIndex2, bool match)
     {
-        Assert.AreEqual(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) < TestCaseTextIndexHelper.ParseTextIndex(textIndex2), match);
+        Assert.That(match, Is.EqualTo(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) < TestCaseTextIndexHelper.ParseTextIndex(textIndex2)));
     }
 
     [TestCase("-1,start", "0,start", true)]
@@ -61,6 +61,6 @@ public class TextIndexTest
     [TestCase("-1,start", "-2,end", false)]
     public void TestOperatorLessOrEqual(string textIndex1, string textIndex2, bool match)
     {
-        Assert.AreEqual(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) <= TestCaseTextIndexHelper.ParseTextIndex(textIndex2), match);
+        Assert.That(match, Is.EqualTo(TestCaseTextIndexHelper.ParseTextIndex(textIndex1) <= TestCaseTextIndexHelper.ParseTextIndex(textIndex2)));
     }
 }

--- a/osu.Framework.Font.Tests/Shaders/OutlineShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/OutlineShaderTest.cs
@@ -21,10 +21,10 @@ public class OutlineShaderTest
         };
 
         var rectangle = shader.ComputeCharacterDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(expectedX, rectangle.X);
-        Assert.AreEqual(expectedY, rectangle.Y);
-        Assert.AreEqual(expectedWidth, rectangle.Width);
-        Assert.AreEqual(expectedHeight, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(expectedX));
+        Assert.That(rectangle.Y, Is.EqualTo(expectedY));
+        Assert.That(rectangle.Width, Is.EqualTo(expectedWidth));
+        Assert.That(rectangle.Height, Is.EqualTo(expectedHeight));
     }
 
     [TestCase(10, -5, -5, 30, 30)]
@@ -38,10 +38,10 @@ public class OutlineShaderTest
         };
 
         var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(expectedX, rectangle.X);
-        Assert.AreEqual(expectedY, rectangle.Y);
-        Assert.AreEqual(expectedWidth, rectangle.Width);
-        Assert.AreEqual(expectedHeight, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(expectedX));
+        Assert.That(rectangle.Y, Is.EqualTo(expectedY));
+        Assert.That(rectangle.Width, Is.EqualTo(expectedWidth));
+        Assert.That(rectangle.Height, Is.EqualTo(expectedHeight));
     }
 
     [TestCase(32)]

--- a/osu.Framework.Font.Tests/Shaders/ShadowShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/ShadowShaderTest.cs
@@ -25,9 +25,9 @@ public class ShadowShaderTest
         };
 
         var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(expectedX, rectangle.X);
-        Assert.AreEqual(expectedY, rectangle.Y);
-        Assert.AreEqual(expectedWidth, rectangle.Width);
-        Assert.AreEqual(expectedHeight, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(expectedX));
+        Assert.That(rectangle.Y, Is.EqualTo(expectedY));
+        Assert.That(rectangle.Width, Is.EqualTo(expectedWidth));
+        Assert.That(rectangle.Height, Is.EqualTo(expectedHeight));
     }
 }

--- a/osu.Framework.Font.Tests/Shaders/StepShaderTest.cs
+++ b/osu.Framework.Font.Tests/Shaders/StepShaderTest.cs
@@ -33,10 +33,10 @@ public class StepShaderTest
         };
 
         var rectangle = shader.ComputeCharacterDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(5 - outline_radius, rectangle.X);
-        Assert.AreEqual(5 - outline_radius, rectangle.Y);
-        Assert.AreEqual(10 + outline_radius * 2, rectangle.Width);
-        Assert.AreEqual(10 + outline_radius * 2, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(5 - outline_radius));
+        Assert.That(rectangle.Y, Is.EqualTo(5 - outline_radius));
+        Assert.That(rectangle.Width, Is.EqualTo(10 + outline_radius * 2));
+        Assert.That(rectangle.Height, Is.EqualTo(10 + outline_radius * 2));
     }
 
     [Test]
@@ -62,10 +62,10 @@ public class StepShaderTest
         };
 
         var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(5 - outline_radius, rectangle.X);
-        Assert.AreEqual(5 - outline_radius, rectangle.Y);
-        Assert.AreEqual(10 + outline_radius * 2 + shadow_offset_x, rectangle.Width);
-        Assert.AreEqual(10 + outline_radius * 2 + shadow_offset_y, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(5 - outline_radius));
+        Assert.That(rectangle.Y, Is.EqualTo(5 - outline_radius));
+        Assert.That(rectangle.Width, Is.EqualTo(10 + outline_radius * 2 + shadow_offset_x));
+        Assert.That(rectangle.Height, Is.EqualTo(10 + outline_radius * 2 + shadow_offset_y));
     }
 
     [Test]
@@ -74,10 +74,10 @@ public class StepShaderTest
         var shader = new StepShader();
 
         var rectangle = shader.ComputeCharacterDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(5, rectangle.X);
-        Assert.AreEqual(5, rectangle.Y);
-        Assert.AreEqual(10, rectangle.Width);
-        Assert.AreEqual(10, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(5));
+        Assert.That(rectangle.Y, Is.EqualTo(5));
+        Assert.That(rectangle.Width, Is.EqualTo(10));
+        Assert.That(rectangle.Height, Is.EqualTo(10));
     }
 
     [Test]
@@ -86,10 +86,10 @@ public class StepShaderTest
         var shader = new StepShader();
 
         var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(5, rectangle.X);
-        Assert.AreEqual(5, rectangle.Y);
-        Assert.AreEqual(10, rectangle.Width);
-        Assert.AreEqual(10, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(5));
+        Assert.That(rectangle.Y, Is.EqualTo(5));
+        Assert.That(rectangle.Width, Is.EqualTo(10));
+        Assert.That(rectangle.Height, Is.EqualTo(10));
     }
 
     [Test]
@@ -104,10 +104,10 @@ public class StepShaderTest
         };
 
         var rectangle = shader.ComputeCharacterDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(5, rectangle.X);
-        Assert.AreEqual(5, rectangle.Y);
-        Assert.AreEqual(10, rectangle.Width);
-        Assert.AreEqual(10, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(5));
+        Assert.That(rectangle.Y, Is.EqualTo(5));
+        Assert.That(rectangle.Width, Is.EqualTo(10));
+        Assert.That(rectangle.Height, Is.EqualTo(10));
     }
 
     [Test]
@@ -122,10 +122,10 @@ public class StepShaderTest
         };
 
         var rectangle = shader.ComputeDrawRectangle(new RectangleF(5, 5, 10, 10));
-        Assert.AreEqual(5, rectangle.X);
-        Assert.AreEqual(5, rectangle.Y);
-        Assert.AreEqual(10, rectangle.Width);
-        Assert.AreEqual(10, rectangle.Height);
+        Assert.That(rectangle.X, Is.EqualTo(5));
+        Assert.That(rectangle.Y, Is.EqualTo(5));
+        Assert.That(rectangle.Width, Is.EqualTo(10));
+        Assert.That(rectangle.Height, Is.EqualTo(10));
     }
 }
 

--- a/osu.Framework.Font.Tests/Utils/TextIndexUtilsTest.cs
+++ b/osu.Framework.Font.Tests/Utils/TextIndexUtilsTest.cs
@@ -22,11 +22,11 @@ public class TextIndexUtilsTest
         if (actualIndex != null)
         {
             var actualTextIndex = new TextIndex(actualIndex.Value, state);
-            Assert.AreEqual(TextIndexUtils.Clamp(textIndex, minIndex, maxIndex), actualTextIndex);
+            Assert.That(actualTextIndex, Is.EqualTo(TextIndexUtils.Clamp(textIndex, minIndex, maxIndex)));
         }
         else
         {
-            Assert.Throws<ArgumentException>(() => TextIndexUtils.Clamp(textIndex, minIndex, maxIndex));
+            Assert.That((Action)(() => TextIndexUtils.Clamp(textIndex, minIndex, maxIndex)), Throws.TypeOf<ArgumentException>());
         }
     }
 
@@ -39,7 +39,7 @@ public class TextIndexUtilsTest
         var textIndex = new TextIndex(index, state);
 
         int actual = TextIndexUtils.ToStringIndex(textIndex);
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [TestCase(TextIndex.IndexState.Start, TextIndex.IndexState.End)]
@@ -47,7 +47,7 @@ public class TextIndexUtilsTest
     public void TestReverseState(TextIndex.IndexState state, TextIndex.IndexState expected)
     {
         var actual = TextIndexUtils.ReverseState(state);
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [TestCase(1, TextIndex.IndexState.End, 1, TextIndex.IndexState.Start)]
@@ -60,7 +60,7 @@ public class TextIndexUtilsTest
 
         var expected = new TextIndex(expectedIndex, expectedState);
         var actual = TextIndexUtils.GetPreviousIndex(textIndex);
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 
     [TestCase(0, TextIndex.IndexState.Start, 0, TextIndex.IndexState.End)]
@@ -73,6 +73,6 @@ public class TextIndexUtilsTest
 
         var expected = new TextIndex(expectedIndex, expectedState);
         var actual = TextIndexUtils.GetNextIndex(textIndex);
-        Assert.AreEqual(expected, actual);
+        Assert.That(actual, Is.EqualTo(expected));
     }
 }

--- a/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
+++ b/osu.Framework.Font.Tests/Visual/Sprites/TestSceneLyricSpriteTextCharacterPosition.cs
@@ -153,10 +153,10 @@ public partial class TestSceneLyricSpriteTextCharacterPosition : BackgroundGridT
         {
             AddStep("Oops", () =>
             {
-                Assert.Catch<ArgumentOutOfRangeException>(() =>
+                Assert.That((Action)(() =>
                 {
                     func();
-                });
+                }), Throws.InstanceOf<ArgumentOutOfRangeException>());
             });
         }
 

--- a/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
+++ b/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NUnit" Version="4.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2026.710.0" />
   </ItemGroup>
   <ItemGroup>

--- a/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
+++ b/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="ppy.osu.Game.Resources" Version="2025.605.1" />
+    <PackageReference Include="ppy.osu.Game.Resources" Version="2026.710.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu.Framework.Font\osu.Framework.Font.csproj" />

--- a/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
+++ b/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
@@ -8,7 +8,7 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2026.710.0" />

--- a/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
+++ b/osu.Framework.Font.Tests/osu.Framework.Font.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageReference Include="ppy.osu.Game.Resources" Version="2026.710.0" />
   </ItemGroup>

--- a/osu.Framework.Font/Graphics/Shaders/CustomizedShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/CustomizedShader.cs
@@ -22,9 +22,6 @@ public abstract class CustomizedShader : ICustomizedShader
 
     public void Unbind() => shader.Unbind();
 
-    public Uniform<T> GetUniform<T>(string name) where T : unmanaged, IEquatable<T>
-        => shader.GetUniform<T>(name);
-
     public void BindUniformBlock(string blockName, IUniformBuffer buffer)
         => shader.BindUniformBlock(blockName, buffer);
 

--- a/osu.Framework.Font/Graphics/Shaders/ICustomizedShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/ICustomizedShader.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) karaoke.dev <contact@karaoke.dev>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Graphics.Rendering;
 
 namespace osu.Framework.Graphics.Shaders;
@@ -29,14 +28,6 @@ public interface ICustomizedShader
     /// Whether this shader is currently bound.
     /// </summary>
     bool IsBound { get; }
-
-    /// <summary>
-    /// Retrieves a uniform from the shader.
-    /// </summary>
-    /// <param name="name">The name of the uniform.</param>
-    /// <returns>The retrieved uniform.</returns>
-    Uniform<T> GetUniform<T>(string name)
-        where T : unmanaged, IEquatable<T>;
 
     /// <summary>
     /// Binds an <see cref="IUniformBuffer"/> to a uniform block of the given name.

--- a/osu.Framework.Font/Graphics/Shaders/StepShader.cs
+++ b/osu.Framework.Font/Graphics/Shaders/StepShader.cs
@@ -38,9 +38,6 @@ public class StepShader : IStepShader, IApplicableToCharacterSize, IApplicableTo
     public void Unbind()
         => throw new NotSupportedException();
 
-    public Uniform<T> GetUniform<T>(string name) where T : unmanaged, IEquatable<T>
-        => throw new NotSupportedException();
-
     public void BindUniformBlock(string blockName, IUniformBuffer buffer)
         => throw new NotSupportedException();
 

--- a/osu.Framework.Font/osu.Framework.Font.csproj
+++ b/osu.Framework.Font/osu.Framework.Font.csproj
@@ -28,7 +28,7 @@
     <NeutralLanguage>en</NeutralLanguage>
   </PropertyGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="ppy.osu.Framework" Version="2025.604.1" />
+    <PackageReference Include="ppy.osu.Framework" Version="2026.629.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\**\*" />


### PR DESCRIPTION
## Summary
- Bump the osu-related group: `ppy.osu.Framework` 2025.604.1 → 2026.629.0, `ppy.osu.Game.Resources` 2025.605.1 → 2026.710.0
- Bump `Microsoft.NET.Test.Sdk` 17.14.1 → 18.8.1
- Bump `NUnit` 3.13.3 → 4.6.1
- Bump `NUnit3TestAdapter` 5.0.0 → 6.2.0

## Why
Keep dependencies current. The osu.Framework bump removed `IShader.GetUniform<T>()` upstream (it was already dead/unreachable code there since the `GlobalPropertyManager` removal), so the unused passthrough was dropped from `ICustomizedShader`/`CustomizedShader`/`StepShader`. The NUnit 4 bump removed the classic `Assert.AreEqual`/`AreNotEqual`/`Throws`/`Catch` methods in favor of the constraint model, so all affected test call sites were migrated to `Assert.That(...)`.

## Test plan
- [x] `dotnet build` succeeds with 0 warnings / 0 errors
- [x] `dotnet test` passes 301/301
- [x] `dotnet list package --outdated` reports nothing outdated